### PR TITLE
refactor(lines2tree): rename to parseString

### DIFF
--- a/__tests__/parseString.test.ts
+++ b/__tests__/parseString.test.ts
@@ -1,8 +1,8 @@
 import fs from 'fs'
 import { NEW_LINE } from '../src/constants'
-import { lines2tree } from '../src/lines2tree'
+import { parseString } from '../src/parse'
 
-describe("lines2tree - transform file to a json tree", () => {
+describe("parseString - transform file to a json tree", () => {
     const filenames = [
         'blank_description',
         'blank_line_end',
@@ -26,7 +26,7 @@ describe("lines2tree - transform file to a json tree", () => {
             const file = fs.readFileSync(`./samples/ics/${filename}.ics`, 'utf-8')
             const json = fs.readFileSync(`./samples/json/${filename}.json`, 'utf-8')
             const lines = file.split(NEW_LINE)
-            const obj = lines2tree(lines)
+            const obj = parseString(lines)
     
             const generatesJSON = JSON.stringify(obj, null, 2)
             expect(generatesJSON).toEqual(json)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { lines2tree } from './lines2tree'
+export { parseString } from './parse'

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -129,7 +129,7 @@ const preprocessing = (lines:string[]):string[] => {
  * 
  * @param rawLines input array of string from the ICS file
  */
-export const lines2tree = (rawLines:string[]):TreeType => {
+export const parseString = (rawLines:string[]):TreeType => {
     const lines:string[] = preprocessing(rawLines)
     return process(lines)
 }


### PR DESCRIPTION
Small change, renames to `parseString` to allow for (possible) future methods!